### PR TITLE
Show offerings only if courses are available (for teacher)

### DIFF
--- a/payment/views.py
+++ b/payment/views.py
@@ -187,15 +187,17 @@ class CoursePaymentIndexView(TemplateView, TeacherOnly):
                 color = "#DDDDDD"
             else:
                 color = "#FFFFFF"
-            tree.append({
-                'text': o.name,
-                'nodes': nodes,
-                'state': {
-                    'expanded': False,
-                },
-                'selectable': False,
-                'backColor': color,
-            })
+                
+            if courses:    
+                tree.append({
+                    'text': o.name,
+                    'nodes': nodes,
+                    'state': {
+                        'expanded': False,
+                    },
+                    'selectable': False,
+                    'backColor': color,
+                })
 
         context['tree'] = json.dumps(tree)
         return context


### PR DESCRIPTION
Its not really nice to show offerings without courses. There are many empty offerings for regular teachers (non admins).